### PR TITLE
Add setup scripts and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # lerobot-vision
-lerobot-vision
+
+This repository contains a minimal ROS 2 workspace for the `lerobot_vision` package. The package demonstrates camera capture, depth computation, object segmentation and robot control. All heavy weight dependencies (YOLO3D, StereoAnywhere, MoveIt etc.) are provided as Git submodules under `external/`.
+
+## Getting started
+
+### 1. Install dependencies
+
+Run `./setup.sh` once to install system requirements, initialise submodules and build the workspace. This script assumes an Ubuntu system with ROS 2 Humble available via apt.
+
+### 2. Running the demo
+
+Use `./run.sh` to activate the Conda environment (if present), source ROS 2 and launch `system_launch.py` which starts the example nodes.
+
+### 3. Project structure
+
+```
+ws/
+  src/
+    lerobot_vision/          # ROS package
+external/                    # third‑party submodules
+```
+
+The `create_structure.sh` helper can recreate the basic directory tree and some boilerplate files.
+
+### 4. Tests
+
+Unit tests live in `ws/src/lerobot_vision/tests`. Run them using:
+
+```bash
+pytest
+```
+
+The tests rely on lightweight stubs for ROS messages so they do not require a full ROS installation during development.
+
+### 5. CI
+
+The GitHub workflow at `.github/workflows/ci.yml` builds the workspace with `colcon`, runs the linters and executes the unit tests with coverage reporting via Codecov.
+
+## Troubleshooting
+
+* Ensure submodules are checked out (`git submodule update --init --recursive`).
+* When running on a fresh system, install ROS 2 Humble before executing the scripts.
+

--- a/create_structure.sh
+++ b/create_structure.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Create basic workspace layout
+mkdir -p ws/src/lerobot_vision/lerobot_vision
+mkdir -p ws/src/lerobot_vision/launch
+mkdir -p ws/src/lerobot_vision/config
+mkdir -p ws/src/lerobot_vision/tests
+
+# Touch boilerplate files
+cat <<'EOPY' > ws/src/lerobot_vision/lerobot_vision/__init__.py
+EOPY
+
+cat <<'EOPY' > ws/src/lerobot_vision/launch/system_launch.py
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(package='lerobot_vision', executable='visualization_node')
+    ])
+EOPY
+
+cat <<'EOPY' > ws/src/lerobot_vision/setup.py
+from setuptools import setup
+
+setup(package_dir={'': 'lerobot_vision'})
+EOPY

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+source /opt/ros/humble/setup.bash
+source "$HOME/miniconda3/etc/profile.d/conda.sh" 2>/dev/null || true
+conda activate lerobot-vision || true
+
+# Launch the system
+ros2 launch lerobot_vision system_launch.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# Install system dependencies for ROS2 and Python tooling
+sudo apt update && sudo apt install -y git python3 python3-pip curl
+
+# Install ROS 2 Humble
+if ! command -v ros2 >/dev/null; then
+  sudo apt install -y ros-humble-desktop
+fi
+
+# Initialize rosdep
+sudo rosdep init 2>/dev/null || true
+rosdep update
+
+# Fetch submodules
+git submodule update --init --recursive
+
+# Install Python requirements
+pip install -r requirements.txt
+
+# Build the workspace
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --workspace ws

--- a/ws/src/lerobot_vision/lerobot_vision/camera_interface.py
+++ b/ws/src/lerobot_vision/lerobot_vision/camera_interface.py
@@ -48,8 +48,12 @@ class StereoCamera:
     def _load_params(cls, path: str) -> None:
         try:
             data = yaml.safe_load(Path(path).read_text())
-            cls.camera_matrix = np.array(data.get("camera_matrix", cls.camera_matrix))
-            cls.dist_coeffs = np.array(data.get("dist_coeffs", cls.dist_coeffs))
+            cls.camera_matrix = np.array(
+                data.get("camera_matrix", cls.camera_matrix)
+            )
+            cls.dist_coeffs = np.array(
+                data.get("dist_coeffs", cls.dist_coeffs)
+            )
         except Exception as exc:  # pragma: no cover - config optional
             logging.error("Failed to load camera parameters: %s", exc)
         return None

--- a/ws/src/lerobot_vision/lerobot_vision/control_node.py
+++ b/ws/src/lerobot_vision/lerobot_vision/control_node.py
@@ -24,7 +24,9 @@ class ControlNode(Node):
         if Robot is None:
             raise RuntimeError("lerobot unavailable")
         p_port = self.get_parameter("port").get_parameter_value().string_value
-        p_id = self.get_parameter("robot_id").get_parameter_value().integer_value
+        p_id = (
+            self.get_parameter("robot_id").get_parameter_value().integer_value
+        )
         self.robot = Robot(p_port, p_id)
         self.sub = self.create_subscription(
             JointTrajectory,

--- a/ws/src/lerobot_vision/lerobot_vision/planner_node.py
+++ b/ws/src/lerobot_vision/lerobot_vision/planner_node.py
@@ -22,7 +22,9 @@ class PlannerNode(Node):
     def __init__(self) -> None:
         super().__init__("planner_node")
         self.declare_parameter("move_group", "manipulator")
-        group_name = self.get_parameter("move_group").get_parameter_value().string_value
+        group_name = (
+            self.get_parameter("move_group").get_parameter_value().string_value
+        )
         self.sub = self.create_subscription(
             String, "/robot/vision/actions", self._cb, 10
         )

--- a/ws/src/lerobot_vision/lerobot_vision/visualization_node.py
+++ b/ws/src/lerobot_vision/lerobot_vision/visualization_node.py
@@ -28,10 +28,14 @@ class VisualizationNode(Node):
         self.declare_parameter("camera_config", str(default_cfg))
         self.declare_parameter("yolo_checkpoint", checkpoint_dir)
         config_path = (
-            self.get_parameter("camera_config").get_parameter_value().string_value
+            self.get_parameter("camera_config")
+            .get_parameter_value()
+            .string_value
         )
         ckpt_path = (
-            self.get_parameter("yolo_checkpoint").get_parameter_value().string_value
+            self.get_parameter("yolo_checkpoint")
+            .get_parameter_value()
+            .string_value
         )
         self.bridge = CvBridge()
         self.camera = StereoCamera(config_path=config_path)


### PR DESCRIPTION
## Summary
- add basic setup, run and workspace structure scripts
- expand README with usage instructions
- break long lines to appease flake8

## Testing
- `flake8 ws/src/lerobot_vision/lerobot_vision`
- `black ws/src/lerobot_vision/lerobot_vision -q --line-length 79`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2496168883319e9c2976077457e0