### PR TITLE
Update requirements and CI for ROS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Install ROS 2 dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y curl gnupg lsb-release
+          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo apt-key add -
+          echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list
+          sudo apt update
+          sudo apt install -y ros-humble-ros-base
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Lint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-rclpy
-cv_bridge
-sensor_msgs
-vision_msgs
-trajectory_msgs
 openai
+numpy
+opencv-python-headless
 pytest
 pytest-cov
 flake8


### PR DESCRIPTION
## Summary
- remove ROS-only packages from requirements
- add numpy and OpenCV packages
- install ROS 2 packages in CI before running pip

## Testing
- `flake8`
- `black --check .`
- `pytest --maxfail=1 --disable-warnings --cov`


------
https://chatgpt.com/codex/tasks/task_e_685dbd4908548331a6ef59f363b80124