### PR TITLE
Add fusion helpers and visualization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ The tests rely on lightweight stubs for ROS messages so they do not require a fu
 
 The GitHub workflow at `.github/workflows/ci.yml` builds the workspace with `colcon`, runs the linters and executes the unit tests with coverage reporting via Codecov.
 
+### 6. Visualization
+
+Image topics can be previewed with `rqt_image_view`:
+
+```bash
+ros2 run rqt_image_view rqt_image_view /openyolo3d/overlay
+ros2 run rqt_image_view rqt_image_view /stereo/depth
+```
+
+Start `web_video_server` to stream a topic in the browser:
+
+```bash
+rosrun web_video_server web_video_server
+```
+
+Then open `http://<robot_ip>:8080/stream?topic=/openyolo3d/overlay` in your browser.
+
 ## Troubleshooting
 
 * Ensure submodules are checked out (`git submodule update --init --recursive`).

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,9 +1,11 @@
 # tests/test_fusion.py
 from unittest import mock
 
-import pytest
+import numpy as np
 import rclpy
 from rclpy.node import Node
+from sensor_msgs.msg import PointCloud2
+from vision_msgs.msg import Detection3DArray
 
 from lerobot_vision.fusion import FusionModule
 
@@ -31,9 +33,17 @@ def test_helper_methods():
     node = Node("test")
     fusion = FusionModule(node)
 
-    with pytest.raises(NotImplementedError):
-        fusion._masks_to_pointcloud2([1, 2])
+    masks = [np.array([[1, 0], [0, 1]], dtype=np.uint8)]
+    labels = ["obj"]
+    poses = [object()]
 
-    with pytest.raises(NotImplementedError):
-        fusion._make_detections([], ["a", "b"], [])
+    pc = fusion._masks_to_pointcloud2(masks)
+    assert isinstance(pc, PointCloud2)
+    assert hasattr(pc, "points")
+    assert len(pc.points) == 2
+
+    det = fusion._make_detections(masks, labels, poses)
+    assert isinstance(det, Detection3DArray)
+    assert len(det.detections) == 1
+    assert det.detections[0]["label"] == "obj"
     rclpy.shutdown()

--- a/ws/src/lerobot_vision/lerobot_vision/fusion.py
+++ b/ws/src/lerobot_vision/lerobot_vision/fusion.py
@@ -51,7 +51,20 @@ class FusionModule:
             A ROS2 ``PointCloud2`` message representing the fused point cloud
             extracted from ``masks``.
         """
-        raise NotImplementedError
+        try:
+            import numpy as np
+        except Exception:  # pragma: no cover - optional dependency
+            np = None  # type: ignore
+
+        points = []
+        if np is not None:
+            for mask in masks:
+                if mask is None:
+                    continue
+                ys, xs = np.nonzero(mask)
+                for x, y in zip(xs, ys):
+                    points.append((float(x), float(y), 0.0))
+        return PointCloud2(points=points)
 
     def _make_detections(
         self, masks: Any, labels: List[str], poses: Any
@@ -59,11 +72,17 @@ class FusionModule:
         """Create a ``Detection3DArray`` message from masks, labels and poses.
 
         Args:
-            masks: List of segmentation masks corresponding to detected objects.
+            masks: Segmentation masks corresponding to detected objects.
             labels: Semantic labels describing each detected object.
             poses: Object poses associated with ``masks`` and ``labels``.
 
         Returns:
             A ROS2 ``Detection3DArray`` message encoding the detections.
         """
-        raise NotImplementedError
+        detections = []
+        for mask, label, pose in zip(masks, labels, poses):
+            detections.append({
+                "label": label,
+                "pose": pose,
+            })
+        return Detection3DArray(detections=detections)


### PR DESCRIPTION
## Summary
- implement point cloud and detection helpers in `FusionModule`
- document rqt and web_video_server usage
- update tests for new helper behaviour

## Testing
- `flake8 ws/src/lerobot_vision/lerobot_vision/fusion.py tests/test_fusion.py`
- `ruff check ws/src/lerobot_vision/lerobot_vision/fusion.py tests/test_fusion.py`
- `pytest -q -c /dev/null`
- `pytest --maxfail=1 --disable-warnings --cov=lerobot_vision -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_685dc27fe508833192a0ec6f6b17e6f0