### PR TITLE
Integrate localization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # lerobot-vision
 
-This repository contains a minimal ROS 2 workspace for the `lerobot_vision` package. The package demonstrates camera capture, depth computation, object segmentation and robot control. All heavy weight dependencies (YOLO3D, StereoAnywhere, MoveIt etc.) are provided as Git submodules under `external/`.
+This repository contains a small ROS 2 workspace for the `lerobot_vision` package.  
+The package demonstrates camera capture, depth computation and 3D object localisation.  
+Additional utilities implement stereo calibration, image rectification and a
+lightweight wrapper around NVIDIA DOPE for pose estimation. Heavy weight
+dependencies (YOLO3D, StereoAnywhere, MoveIt etc.) are provided as Git
+submodules under `external/`.
 
 ## Getting started
 
@@ -20,6 +25,15 @@ ws/
     lerobot_vision/          # ROS package
 external/                    # third‑party submodules
 ```
+
+Key modules include:
+
+- ``StereoCalibrator`` – assists with intrinsic and extrinsic calibration
+- ``ImageRectifier`` – rectifies image pairs using calibration results
+- ``DepthEngine`` – wraps StereoAnywhere for disparity estimation
+- ``Yolo3DEngine`` – object detection via OpenYOLO3D
+- ``PoseEstimator`` – thin wrapper around NVIDIA DOPE
+- ``ObjectLocalizer`` – fuses masks, depth and poses into 3D coordinates
 
 The `create_structure.sh` helper can recreate the basic directory tree and some boilerplate files.
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from lerobot_vision.object_localizer import localize_objects
+from lerobot_vision.pose_estimator import PoseEstimator
+from lerobot_vision.stereo_calibrator import StereoCalibrator
+from lerobot_vision.image_rectifier import ImageRectifier
+
+
+def test_localize_objects():
+    masks = [np.array([[1, 0], [0, 0]], dtype=np.uint8)]
+    depth = np.array([[1.0, 1.0], [1.0, 1.0]], dtype=float)
+    cam = np.array([[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]])
+    result = localize_objects(masks, depth, cam)
+    assert len(result) == 1
+    label, xyz = result[0]
+    assert label == "obj_0"
+    assert xyz.shape == (3,)
+
+
+def test_pose_estimator_noop(monkeypatch):
+    monkeypatch.setattr(
+        "lerobot_vision.pose_estimator.DOPEEstimator", None, raising=False
+    )
+    est = PoseEstimator()
+    out = est.estimate(np.zeros((1, 1, 3), dtype=np.uint8))
+    assert out == []
+
+
+def test_stereo_calibrator_no_corners():
+    calib = StereoCalibrator()
+    with pytest.raises(RuntimeError):
+        calib.calibrate((10, 10))
+
+
+def test_image_rectifier_identity():
+    m = np.eye(3)
+    d = np.zeros(5)
+    rect = ImageRectifier(m, d, m, d, (2, 2), translation=np.array([1.0, 0, 0]))
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    l, r = rect.rectify(img, img)
+    assert l.shape == img.shape
+    assert r.shape == img.shape
+

--- a/tests/test_visualization_node.py
+++ b/tests/test_visualization_node.py
@@ -43,6 +43,14 @@ def test_on_timer(monkeypatch):
         ),
     )
     monkeypatch.setattr(
+        "lerobot_vision.visualization_node.PoseEstimator",
+        mock.Mock(return_value=mock.Mock(estimate=mock.Mock(return_value=[]))),
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.localize_objects",
+        mock.Mock(return_value=[]),
+    )
+    monkeypatch.setattr(
         "lerobot_vision.visualization_node.CvBridge",
         mock.Mock(
             return_value=mock.Mock(

--- a/ws/src/lerobot_vision/lerobot_vision/image_rectifier.py
+++ b/ws/src/lerobot_vision/lerobot_vision/image_rectifier.py
@@ -1,0 +1,51 @@
+# ws/src/lerobot_vision/lerobot_vision/image_rectifier.py
+"""Rectify stereo images using calibration parameters."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+
+class ImageRectifier:
+    """Apply rectification maps to image pairs."""
+
+    def __init__(
+        self,
+        left_camera_matrix: np.ndarray,
+        left_dist_coeffs: np.ndarray,
+        right_camera_matrix: np.ndarray,
+        right_dist_coeffs: np.ndarray,
+        image_size: Tuple[int, int],
+        rotation: np.ndarray | None = None,
+        translation: np.ndarray | None = None,
+    ) -> None:
+        self.M1 = left_camera_matrix
+        self.D1 = left_dist_coeffs
+        self.M2 = right_camera_matrix
+        self.D2 = right_dist_coeffs
+        R = np.eye(3) if rotation is None else rotation
+        T = np.array([1.0, 0.0, 0.0]) if translation is None else translation
+        R1, R2, P1, P2, Q, _, _ = cv2.stereoRectify(
+            self.M1,
+            self.D1,
+            self.M2,
+            self.D2,
+            image_size,
+            R,
+            T,
+        )
+        self.map1x, self.map1y = cv2.initUndistortRectifyMap(
+            self.M1, self.D1, R1, P1, image_size, cv2.CV_32FC1
+        )
+        self.map2x, self.map2y = cv2.initUndistortRectifyMap(
+            self.M2, self.D2, R2, P2, image_size, cv2.CV_32FC1
+        )
+
+    def rectify(self, left: np.ndarray, right: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        left_r = cv2.remap(left, self.map1x, self.map1y, cv2.INTER_LINEAR)
+        right_r = cv2.remap(right, self.map2x, self.map2y, cv2.INTER_LINEAR)
+        return left_r, right_r
+

--- a/ws/src/lerobot_vision/lerobot_vision/object_localizer.py
+++ b/ws/src/lerobot_vision/lerobot_vision/object_localizer.py
@@ -1,0 +1,47 @@
+# ws/src/lerobot_vision/lerobot_vision/object_localizer.py
+"""Fuse masks, depth and poses to obtain 3D object positions."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+
+def localize_objects(
+    masks: List[np.ndarray],
+    depth: np.ndarray,
+    camera_matrix: np.ndarray,
+) -> List[Tuple[str, np.ndarray]]:
+    """Compute 3D coordinates from masks and depth.
+
+    Args:
+        masks: List of binary segmentation masks.
+        depth: Depth map corresponding to the masks.
+        camera_matrix: Intrinsic camera matrix.
+
+    Returns:
+        List of tuples ``(label, xyz)`` representing object labels and their
+        3D positions in camera coordinates.
+    """
+    results: List[Tuple[str, np.ndarray]] = []
+    fx = camera_matrix[0, 0]
+    fy = camera_matrix[1, 1]
+    cx = camera_matrix[0, 2]
+    cy = camera_matrix[1, 2]
+
+    for idx, mask in enumerate(masks):
+        if mask is None or mask.size == 0:
+            continue
+        ys, xs = np.nonzero(mask > 0)
+        if len(xs) == 0:
+            continue
+        z_vals = depth[ys, xs]
+        z = float(np.median(z_vals))
+        u = float(np.median(xs))
+        v = float(np.median(ys))
+        x = (u - cx) * z / fx
+        y = (v - cy) * z / fy
+        results.append((f"obj_{idx}", np.array([x, y, z], dtype=float)))
+    return results

--- a/ws/src/lerobot_vision/lerobot_vision/pose_estimator.py
+++ b/ws/src/lerobot_vision/lerobot_vision/pose_estimator.py
@@ -1,0 +1,48 @@
+# ws/src/lerobot_vision/lerobot_vision/pose_estimator.py
+"""Pose estimation wrapper using DOPE."""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Tuple
+
+import numpy as np
+
+try:
+    from isaac_ros_pose_estimation.dope import DOPEEstimator  # pragma: no cover
+except Exception as exc:  # pragma: no cover - optional dependency
+    DOPEEstimator = None  # type: ignore
+    logging.error("DOPE import failed: %s", exc)
+
+
+class PoseEstimator:
+    """Estimate 6-DoF poses for known objects."""
+
+    def __init__(self) -> None:
+        if DOPEEstimator is not None:
+            try:
+                self.estimator = DOPEEstimator()
+            except Exception as exc:  # pragma: no cover - runtime path
+                logging.error("DOPE init failed: %s", exc)
+                self.estimator = None
+        else:
+            self.estimator = None
+
+    def estimate(self, image: np.ndarray) -> List[Tuple[np.ndarray, np.ndarray]]:
+        """Estimate object poses from an RGB image.
+
+        Args:
+            image: The input RGB image.
+
+        Returns:
+            A list of ``(position, orientation)`` tuples where ``position`` is
+            a ``(x, y, z)`` array and ``orientation`` is a quaternion
+            ``(x, y, z, w)``.
+        """
+        if self.estimator is None:
+            return []
+        try:
+            return self.estimator.infer(image)
+        except Exception as exc:  # pragma: no cover - runtime path
+            logging.error("Pose estimation failed: %s", exc)
+            return []

--- a/ws/src/lerobot_vision/lerobot_vision/stereo_calibrator.py
+++ b/ws/src/lerobot_vision/lerobot_vision/stereo_calibrator.py
@@ -1,0 +1,64 @@
+# ws/src/lerobot_vision/lerobot_vision/stereo_calibrator.py
+"""Utility to calibrate a stereo camera setup."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+import yaml
+
+
+class StereoCalibrator:
+    """Perform stereo calibration from image pairs."""
+
+    def __init__(self, board_size: Tuple[int, int] = (7, 6), square_size: float = 1.0) -> None:
+        self.board_size = board_size
+        self.square_size = square_size
+        self.objpoints: List[np.ndarray] = []
+        self.left_points: List[np.ndarray] = []
+        self.right_points: List[np.ndarray] = []
+
+    def add_corners(self, left: np.ndarray, right: np.ndarray) -> bool:
+        """Detect chessboard corners and store them."""
+        pattern_size = self.board_size
+        ret_l, corners_l = cv2.findChessboardCorners(left, pattern_size)
+        ret_r, corners_r = cv2.findChessboardCorners(right, pattern_size)
+        if not ret_l or not ret_r:
+            return False
+        term = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 30, 0.001)
+        corners_l = cv2.cornerSubPix(cv2.cvtColor(left, cv2.COLOR_BGR2GRAY), corners_l, (11, 11), (-1, -1), term)
+        corners_r = cv2.cornerSubPix(cv2.cvtColor(right, cv2.COLOR_BGR2GRAY), corners_r, (11, 11), (-1, -1), term)
+        objp = np.zeros((np.prod(pattern_size), 3), np.float32)
+        objp[:, :2] = np.indices(pattern_size).T.reshape(-1, 2)
+        objp *= self.square_size
+        self.objpoints.append(objp)
+        self.left_points.append(corners_l)
+        self.right_points.append(corners_r)
+        return True
+
+    def calibrate(self, image_size: Tuple[int, int]) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Run stereo calibration."""
+        if not self.objpoints:
+            raise RuntimeError("No corners accumulated")
+        ret_l, m1, d1, _, _ = cv2.calibrateCamera(self.objpoints, self.left_points, image_size, None, None)
+        ret_r, m2, d2, _, _ = cv2.calibrateCamera(self.objpoints, self.right_points, image_size, None, None)
+        if not ret_l or not ret_r:
+            raise RuntimeError("Calibration failed")
+        return m1, d1, m2, d2
+
+    def save(self, path: str, m1: np.ndarray, d1: np.ndarray, m2: np.ndarray, d2: np.ndarray) -> None:
+        data = {
+            "left_camera_matrix": m1.tolist(),
+            "left_dist_coeffs": d1.tolist(),
+            "right_camera_matrix": m2.tolist(),
+            "right_dist_coeffs": d2.tolist(),
+        }
+        try:
+            Path(path).write_text(yaml.safe_dump(data))
+        except Exception as exc:  # pragma: no cover - file IO
+            logging.error("Failed to save calibration: %s", exc)
+


### PR DESCRIPTION
## Summary
- implement new modules for DOPE pose estimation, stereo calibration, rectification and localization
- extend visualization node to make use of the new utilities
- document new modules in README
- add tests for the added modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8e48290483319e18b95c888ec429