### PR TITLE
Implement 3D overlay and custom depth loading

### DIFF
--- a/tests/test_depth_engine.py
+++ b/tests/test_depth_engine.py
@@ -21,3 +21,15 @@ def test_compute_depth_success():
     result = engine.compute_depth(dummy, dummy)
     assert result is depth
     engine.engine.infer.assert_called_once()
+
+
+def test_init_custom_model():
+    class Dummy:
+        def __init__(self, *args, **kwargs):
+            Dummy.args = args
+            Dummy.kwargs = kwargs
+
+    with mock.patch("lerobot_vision.depth_engine.StereoAnywhere", Dummy):
+        engine = DepthEngine(model_path="model.pth")
+        assert isinstance(engine.engine, Dummy)
+        assert Dummy.kwargs == {"model_path": "model.pth"}

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -11,10 +11,11 @@ def test_localize_objects():
     masks = [np.array([[1, 0], [0, 0]], dtype=np.uint8)]
     depth = np.array([[1.0, 1.0], [1.0, 1.0]], dtype=float)
     cam = np.array([[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]])
-    result = localize_objects(masks, depth, cam)
+    result = localize_objects(masks, depth, cam, ["cup"])
     assert len(result) == 1
-    label, xyz = result[0]
-    assert label == "obj_0"
+    label, xyz, pose = result[0]
+    assert label == "cup"
+    assert pose is None
     assert xyz.shape == (3,)
 
 
@@ -36,9 +37,10 @@ def test_stereo_calibrator_no_corners():
 def test_image_rectifier_identity():
     m = np.eye(3)
     d = np.zeros(5)
-    rect = ImageRectifier(m, d, m, d, (2, 2), translation=np.array([1.0, 0, 0]))
+    rect = ImageRectifier(
+        m, d, m, d, (2, 2), translation=np.array([1.0, 0, 0])
+    )
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     l, r = rect.rectify(img, img)
     assert l.shape == img.shape
     assert r.shape == img.shape
-

--- a/ws/src/lerobot_vision/lerobot_vision/depth_engine.py
+++ b/ws/src/lerobot_vision/lerobot_vision/depth_engine.py
@@ -27,7 +27,10 @@ class DepthEngine:
         self.model_path = model_path
         if isinstance(StereoAnywhere, type):
             try:
-                self.engine = StereoAnywhere(pretrained=True)
+                if model_path is not None:
+                    self.engine = StereoAnywhere(model_path=model_path)
+                else:
+                    self.engine = StereoAnywhere(pretrained=True)
             except Exception as exc:  # pragma: no cover - runtime path
                 self.engine = None
                 logging.error("StereoAnywhere init failed: %s", exc)

--- a/ws/src/lerobot_vision/lerobot_vision/fusion.py
+++ b/ws/src/lerobot_vision/lerobot_vision/fusion.py
@@ -81,8 +81,10 @@ class FusionModule:
         """
         detections = []
         for mask, label, pose in zip(masks, labels, poses):
-            detections.append({
-                "label": label,
-                "pose": pose,
-            })
+            detections.append(
+                {
+                    "label": label,
+                    "pose": pose,
+                }
+            )
         return Detection3DArray(detections=detections)

--- a/ws/src/lerobot_vision/lerobot_vision/gui.py
+++ b/ws/src/lerobot_vision/lerobot_vision/gui.py
@@ -27,7 +27,11 @@ class VisionGUI:  # pragma: no cover - GUI helper
         self.left_label.pack(side=tk.LEFT)
         self.right_label = tk.Label(self.root)
         self.right_label.pack(side=tk.LEFT)
-        btn = tk.Button(self.root, text="Capture Corners", command=self._capture)
+        btn = tk.Button(
+            self.root,
+            text="Capture Corners",
+            command=self._capture,
+        )
         btn.pack(fill=tk.X)
         btn2 = tk.Button(self.root, text="Calibrate", command=self._calibrate)
         btn2.pack(fill=tk.X)
@@ -45,7 +49,9 @@ class VisionGUI:  # pragma: no cover - GUI helper
             self.root.update_idletasks()
             self.root.update()
 
-    def _show_image(self, img: np.ndarray, widget: tk.Label) -> None:  # pragma: no cover
+    def _show_image(
+        self, img: np.ndarray, widget: tk.Label
+    ) -> None:  # pragma: no cover
         rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         im = ImageTk.PhotoImage(Image.fromarray(rgb))
         widget.configure(image=im)

--- a/ws/src/lerobot_vision/lerobot_vision/image_rectifier.py
+++ b/ws/src/lerobot_vision/lerobot_vision/image_rectifier.py
@@ -44,8 +44,9 @@ class ImageRectifier:
             self.M2, self.D2, R2, P2, image_size, cv2.CV_32FC1
         )
 
-    def rectify(self, left: np.ndarray, right: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def rectify(
+        self, left: np.ndarray, right: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
         left_r = cv2.remap(left, self.map1x, self.map1y, cv2.INTER_LINEAR)
         right_r = cv2.remap(right, self.map2x, self.map2y, cv2.INTER_LINEAR)
         return left_r, right_r
-

--- a/ws/src/lerobot_vision/lerobot_vision/pose_estimator.py
+++ b/ws/src/lerobot_vision/lerobot_vision/pose_estimator.py
@@ -9,7 +9,9 @@ from typing import List, Tuple
 import numpy as np
 
 try:
-    from isaac_ros_pose_estimation.dope import DOPEEstimator  # pragma: no cover
+    from isaac_ros_pose_estimation.dope import (  # pragma: no cover
+        DOPEEstimator,
+    )
 except Exception as exc:  # pragma: no cover - optional dependency
     DOPEEstimator = None  # type: ignore
     logging.error("DOPE import failed: %s", exc)
@@ -28,7 +30,9 @@ class PoseEstimator:
         else:
             self.estimator = None
 
-    def estimate(self, image: np.ndarray) -> List[Tuple[np.ndarray, np.ndarray]]:
+    def estimate(
+        self, image: np.ndarray
+    ) -> List[Tuple[np.ndarray, np.ndarray]]:
         """Estimate object poses from an RGB image.
 
         Args:

--- a/ws/src/lerobot_vision/lerobot_vision/stereo_calibrator.py
+++ b/ws/src/lerobot_vision/lerobot_vision/stereo_calibrator.py
@@ -15,7 +15,9 @@ import yaml
 class StereoCalibrator:
     """Perform stereo calibration from image pairs."""
 
-    def __init__(self, board_size: Tuple[int, int] = (7, 6), square_size: float = 1.0) -> None:
+    def __init__(
+        self, board_size: Tuple[int, int] = (7, 6), square_size: float = 1.0
+    ) -> None:
         self.board_size = board_size
         self.square_size = square_size
         self.objpoints: List[np.ndarray] = []
@@ -30,8 +32,20 @@ class StereoCalibrator:
         if not ret_l or not ret_r:
             return False
         term = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 30, 0.001)
-        corners_l = cv2.cornerSubPix(cv2.cvtColor(left, cv2.COLOR_BGR2GRAY), corners_l, (11, 11), (-1, -1), term)
-        corners_r = cv2.cornerSubPix(cv2.cvtColor(right, cv2.COLOR_BGR2GRAY), corners_r, (11, 11), (-1, -1), term)
+        corners_l = cv2.cornerSubPix(
+            cv2.cvtColor(left, cv2.COLOR_BGR2GRAY),
+            corners_l,
+            (11, 11),
+            (-1, -1),
+            term,
+        )
+        corners_r = cv2.cornerSubPix(
+            cv2.cvtColor(right, cv2.COLOR_BGR2GRAY),
+            corners_r,
+            (11, 11),
+            (-1, -1),
+            term,
+        )
         objp = np.zeros((np.prod(pattern_size), 3), np.float32)
         objp[:, :2] = np.indices(pattern_size).T.reshape(-1, 2)
         objp *= self.square_size
@@ -40,9 +54,14 @@ class StereoCalibrator:
         self.right_points.append(corners_r)
         return True
 
-    def calibrate(
-        self, image_size: Tuple[int, int]
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    def calibrate(self, image_size: Tuple[int, int]) -> Tuple[
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+    ]:
         """Run stereo calibration and return intrinsics and extrinsics."""
         if not self.objpoints:
             raise RuntimeError("No corners accumulated")
@@ -56,8 +75,8 @@ class StereoCalibrator:
         if not ret_l or not ret_r:
             raise RuntimeError("Calibration failed")
 
-        ret, _, _, r, t, _, _ = cv2.stereoCalibrate(  # pragma: no cover - heavy
-            # calibration
+        ret, _, _, r, t, _, _ = cv2.stereoCalibrate(
+            # pragma: no cover - heavy calibration
             self.objpoints,
             self.left_points,
             self.right_points,
@@ -96,4 +115,3 @@ class StereoCalibrator:
             Path(path).write_text(yaml.safe_dump(data))
         except Exception as exc:  # pragma: no cover - file IO
             logging.error("Failed to save calibration: %s", exc)
-


### PR DESCRIPTION
## Summary
- allow DepthEngine to load custom model path
- expand `localize_objects` to accept labels and optional poses
- show 3D information and pose orientation in visualization overlays
- update tests for new behaviour and add tests for overlays
- clean up long lines and unused imports across modules

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9959d59c8331846fa84d395a139b