### PR TITLE
Add calibration wizard to VisionGUI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
       - pytest-cov
       - flake8
       - black
+      - matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest-cov
 flake8
 black
 PyYAML
+matplotlib

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,84 @@
+import numpy as np
+from unittest import mock
+
+import lerobot_vision.gui as gui_mod
+
+
+def setup_gui(monkeypatch):
+    class DummyTk:
+        def title(self, _):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def update(self):
+            pass
+
+        def mainloop(self):
+            pass
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+    class DummyVar:
+        def set(self, _):
+            pass
+
+    class DummyThread:
+        def __init__(self, *a, **k):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(gui_mod.tk, "Tk", DummyTk)
+    monkeypatch.setattr(gui_mod.tk, "Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr(gui_mod.tk, "Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr(gui_mod.tk, "StringVar", DummyVar)
+    monkeypatch.setattr(gui_mod.threading, "Thread", DummyThread)
+
+    cam = mock.Mock()
+    cam.get_frames.return_value = (
+        np.zeros((1, 1, 3), dtype=np.uint8),
+        np.zeros((1, 1, 3), dtype=np.uint8),
+    )
+    return cam
+
+
+def test_wizard_flow(monkeypatch):
+    cam = setup_gui(monkeypatch)
+    gui = gui_mod.VisionGUI(cam)
+    gui._review = mock.Mock()
+    gui._calibrate = mock.Mock()
+
+    gui.next_step()
+    assert gui.step_idx == 1
+    gui._review.assert_called_once()
+
+    gui.next_step()
+    assert gui.step_idx == 2
+    gui._calibrate.assert_called_once()
+
+    gui.prev_step()
+    assert gui.step_idx == 1
+
+
+def test_wizard_bounds(monkeypatch):
+    cam = setup_gui(monkeypatch)
+    gui = gui_mod.VisionGUI(cam)
+
+    gui.step_idx = len(gui.steps) - 1
+    gui.next_step()
+    assert gui.step_idx == len(gui.steps) - 1
+
+    gui.step_idx = 0
+    gui.prev_step()
+    assert gui.step_idx == 0

--- a/ws/src/lerobot_vision/lerobot_vision/gui.py
+++ b/ws/src/lerobot_vision/lerobot_vision/gui.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import cv2
 from PIL import Image, ImageTk
 import numpy as np
+import matplotlib.pyplot as plt
 
 from .camera_interface import AsyncStereoCamera
 from .stereo_calibrator import StereoCalibrator
@@ -27,15 +28,38 @@ class VisionGUI:  # pragma: no cover - GUI helper
         self.left_label.pack(side=tk.LEFT)
         self.right_label = tk.Label(self.root)
         self.right_label.pack(side=tk.LEFT)
-        btn = tk.Button(
+
+        self.status_var = tk.StringVar()
+        self.status = tk.Label(self.root, textvariable=self.status_var)
+        self.status.pack(fill=tk.X)
+
+        capture_btn = tk.Button(
             self.root,
             text="Capture Corners",
             command=self._capture,
         )
-        btn.pack(fill=tk.X)
-        btn2 = tk.Button(self.root, text="Calibrate", command=self._calibrate)
-        btn2.pack(fill=tk.X)
+        capture_btn.pack(fill=tk.X)
+
+        self.prev_btn = tk.Button(
+            self.root, text="Previous", command=self.prev_step
+        )
+        self.prev_btn.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        self.next_btn = tk.Button(
+            self.root, text="Next", command=self.next_step
+        )
+        self.next_btn.pack(side=tk.LEFT, fill=tk.X, expand=True)
+
+        self.steps = [
+            "Capture corner pairs",
+            "Review detected patterns",
+            "Reprojection error",
+        ]
+        self.step_idx = 0
+        self.captured_pairs: list[tuple[np.ndarray, np.ndarray]] = []
+        self.errors: list[tuple[float, float]] = []
+
         self._running = True
+        self._update_status()
         threading.Thread(target=self._update_loop, daemon=True).start()
 
     def _update_loop(self) -> None:  # pragma: no cover
@@ -60,7 +84,8 @@ class VisionGUI:  # pragma: no cover - GUI helper
     def _capture(self) -> None:  # pragma: no cover
         try:
             left, right = self.camera.get_frames()
-            self.calibrator.add_corners(left, right)
+            if self.calibrator.add_corners(left, right):
+                self.captured_pairs.append((left.copy(), right.copy()))
         except Exception:
             pass
 
@@ -68,9 +93,69 @@ class VisionGUI:  # pragma: no cover - GUI helper
         if not self.calibrator.objpoints:
             return
         h, w = self.camera.get_frames()[0].shape[:2]
-        m1, d1, m2, d2, r, t = self.calibrator.calibrate((w, h))
+        (
+            m1,
+            d1,
+            m2,
+            d2,
+            r,
+            t,
+            self.errors,
+        ) = self.calibrator.calibrate((w, h), return_errors=True)
         save_path = Path("calibration.yaml")
         self.calibrator.save(str(save_path), m1, d1, m2, d2, r, t)
+        self._show_error_plot()
+
+    def _review(self) -> None:  # pragma: no cover
+        if not self.captured_pairs:
+            return
+        left, right = self.captured_pairs[-1]
+        corners_l = self.calibrator.left_points[-1]
+        corners_r = self.calibrator.right_points[-1]
+        cv2.drawChessboardCorners(
+            left, self.calibrator.board_size, corners_l, True
+        )
+        cv2.drawChessboardCorners(
+            right, self.calibrator.board_size, corners_r, True
+        )
+        self._show_image(left, self.left_label)
+        self._show_image(right, self.right_label)
+
+    def _show_error_plot(self) -> None:  # pragma: no cover
+        if not self.errors:
+            return
+        l_err = [e[0] for e in self.errors]
+        r_err = [e[1] for e in self.errors]
+        plt.figure()
+        plt.plot(l_err, label="left")
+        plt.plot(r_err, label="right")
+        plt.xlabel("Image Pair")
+        plt.ylabel("Reprojection Error")
+        plt.legend()
+        plt.show(block=False)
+        plt.close()
+
+    def _update_status(self) -> None:  # pragma: no cover
+        step = self.step_idx + 1
+        total = len(self.steps)
+        text = f"Step {step}/{total}: {self.steps[self.step_idx]}"
+        self.status_var.set(text)
+
+    def next_step(self) -> None:  # pragma: no cover
+        if self.step_idx >= len(self.steps) - 1:
+            return
+        self.step_idx += 1
+        if self.step_idx == 1:
+            self._review()
+        elif self.step_idx == 2:
+            self._calibrate()
+        self._update_status()
+
+    def prev_step(self) -> None:  # pragma: no cover
+        if self.step_idx == 0:
+            return
+        self.step_idx -= 1
+        self._update_status()
 
     def run(self) -> None:  # pragma: no cover
         self.root.mainloop()


### PR DESCRIPTION
## Summary
- add matplotlib to dependencies
- extend `VisionGUI` with a multi-step calibration wizard
- compute reprojection errors in `StereoCalibrator`
- add tests for the wizard logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea34f075c8331847079760493af44