### PR TITLE
Enable GPU acceleration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Key modules include:
 
 - ``StereoCalibrator`` – assists with intrinsic and extrinsic calibration
 - ``ImageRectifier`` – rectifies image pairs using calibration results
-- ``DepthEngine`` – wraps StereoAnywhere for disparity estimation
+- ``DepthEngine`` – uses CUDA SGBM by default with optional StereoAnywhere fallback
 - ``Yolo3DEngine`` – object detection via OpenYOLO3D
 - ``PoseEstimator`` – thin wrapper around NVIDIA DOPE
 - ``ObjectLocalizer`` – fuses masks, depth and poses into 3D coordinates

--- a/tests/test_depth_engine.py
+++ b/tests/test_depth_engine.py
@@ -7,7 +7,7 @@ from lerobot_vision.depth_engine import DepthEngine
 
 
 def test_compute_depth_invalid():
-    engine = DepthEngine(model_path=None)
+    engine = DepthEngine(model_path=None, use_cuda=False)
     engine.engine = mock.Mock()
     with pytest.raises(ValueError):
         engine.compute_depth("bad", np.zeros((1, 1)))
@@ -16,7 +16,7 @@ def test_compute_depth_invalid():
 def test_compute_depth_success():
     dummy = np.zeros((1, 1, 3), dtype=np.uint8)
     depth = np.zeros((1, 1), dtype=np.float32)
-    engine = DepthEngine(model_path=None)
+    engine = DepthEngine(model_path=None, use_cuda=False)
     engine.engine = mock.Mock(infer=mock.Mock(return_value=depth))
     result = engine.compute_depth(dummy, dummy)
     assert result is depth
@@ -30,7 +30,7 @@ def test_init_custom_model():
             Dummy.kwargs = kwargs
 
     with mock.patch("lerobot_vision.depth_engine.StereoAnywhere", Dummy):
-        engine = DepthEngine(model_path="model.pth")
+        engine = DepthEngine(model_path="model.pth", use_cuda=False)
         assert isinstance(engine.engine, Dummy)
         assert Dummy.kwargs == {"model_path": "model.pth"}
 

--- a/ws/src/lerobot_vision/lerobot_vision/depth_engine.py
+++ b/ws/src/lerobot_vision/lerobot_vision/depth_engine.py
@@ -1,5 +1,5 @@
 # ws/src/lerobot_vision/lerobot_vision/depth_engine.py
-"""Depth engine wrapper around Stereo Anywhere with CUDA fallback."""
+"""Depth engine using CUDA acceleration with optional CPU fallback."""
 
 from __future__ import annotations
 
@@ -27,13 +27,13 @@ class DepthEngine:
     """Compute depth from stereo images."""
 
     def __init__(
-        self, model_path: Optional[str] = None, *, use_cuda: bool = False
+        self, model_path: Optional[str] = None, *, use_cuda: bool = True
     ) -> None:
         """Create the depth engine.
 
         Args:
             model_path: Optional path to a trained ``StereoAnywhere`` model.
-            use_cuda: Force use of the CUDA/SGBM fallback implementation.
+            use_cuda: Use CUDA accelerated SGBM. Set ``False`` for CPU fallback.
         """
         self.model_path = model_path
         self.use_cuda = use_cuda


### PR DESCRIPTION
## Summary
- default DepthEngine to CUDA SGBM
- update tests for optional CPU-only mode
- document GPU default in README

## Testing
- `pip install -q pytest-cov`
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea9867f8883319d1795aaa5a642a6