### PR TITLE
Publish rectified images in visualization node

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,16 @@ Image topics can be previewed with `rqt_image_view`:
 ```bash
 ros2 run rqt_image_view rqt_image_view /openyolo3d/overlay
 ros2 run rqt_image_view rqt_image_view /stereo/depth
+ros2 run rqt_image_view rqt_image_view /stereo/left_raw
+ros2 run rqt_image_view rqt_image_view /stereo/right_raw
+ros2 run rqt_image_view rqt_image_view /stereo/left_rectified
+ros2 run rqt_image_view rqt_image_view /stereo/right_rectified
 ```
+
+The visualization node publishes the raw and rectified camera frames as well as
+the computed depth map. These outputs can be enabled individually via the
+`publish_left_raw`, `publish_right_raw`, `publish_left_rectified`,
+`publish_right_rectified` and `publish_depth` ROS parameters.
 
 Start `web_video_server` to stream a topic in the browser:
 

--- a/tests/test_visualization_node.py
+++ b/tests/test_visualization_node.py
@@ -33,6 +33,11 @@ def test_on_timer(monkeypatch):
         raising=False,
     )
     monkeypatch.setattr(
+        "lerobot_vision.visualization_node.StereoCamera.dist_coeffs",
+        np.zeros(5),
+        raising=False,
+    )
+    monkeypatch.setattr(
         "lerobot_vision.visualization_node.DepthEngine",
         mock.Mock(
             return_value=mock.Mock(
@@ -68,6 +73,17 @@ def test_on_timer(monkeypatch):
                 cv2_to_imgmsg=mock.Mock(return_value=Image())
             )  # noqa: E501
         ),
+    )
+    class DummyRect:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def rectify(self, left, right):
+            return left, right
+
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.ImageRectifier",
+        DummyRect,
     )
 
     rclpy.init(args=None)


### PR DESCRIPTION
## Summary
- add optional publishers for raw/rectified images and depth
- use `ImageRectifier` inside the timer callback
- expose parameters to toggle image outputs
- document the new topics in README
- extend unit tests for the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaed4ba848331a602bb346da8f877