### PR TITLE
Add runtime publisher control

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ the computed depth map. These outputs can be enabled individually via the
 `publish_left_raw`, `publish_right_raw`, `publish_left_rectified`,
 `publish_right_rectified` and `publish_depth` ROS parameters.
 
+You can toggle these publishers at runtime using the `toggle_publisher` service:
+
+```bash
+ros2 service call /visualization_node/toggle_publisher \
+  lerobot_vision/srv/TogglePublisher "{publisher: 'left_raw', enable: true}"
+ros2 service call /visualization_node/toggle_publisher \
+  lerobot_vision/srv/TogglePublisher "{publisher: 'left_raw', enable: false}"
+```
+
 Start `web_video_server` to stream a topic in the browser:
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,17 @@ if "rclpy" not in sys.modules:
         def create_timer(self, *args, **kwargs):
             return None
 
+        def create_service(self, srv_type, name, callback):
+            class Service:
+                def __init__(self, cb):
+                    self._cb = cb
+
+                def call(self, request):
+                    response = srv_type.Response()
+                    return self._cb(request, response)
+
+            return Service(callback)
+
     node_module.Node = Node
     rclpy.node = node_module
     rclpy.init = lambda args=None: None

--- a/tests/test_visualization_node.py
+++ b/tests/test_visualization_node.py
@@ -7,7 +7,10 @@ import numpy as np
 import rclpy
 from sensor_msgs.msg import Image
 
-from lerobot_vision.visualization_node import VisualizationNode
+from lerobot_vision.visualization_node import (
+    VisualizationNode,
+    TogglePublisher,
+)
 
 
 def test_on_timer(monkeypatch):
@@ -74,6 +77,7 @@ def test_on_timer(monkeypatch):
             )  # noqa: E501
         ),
     )
+
     class DummyRect:
         def __init__(self, *args, **kwargs):
             pass
@@ -151,4 +155,104 @@ def test_draw_overlay(monkeypatch):
     cv2.rectangle.assert_called_once()
     assert cv2.putText.call_count >= 1
     assert cv2.line.call_count == 3
+    rclpy.shutdown()
+
+
+def test_toggle_service(monkeypatch):
+    class DummyCam:
+        camera_matrix = np.eye(3)
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_frames(self):
+            return (
+                np.zeros((1, 1, 3), dtype=np.uint8),
+                np.zeros((1, 1, 3), dtype=np.uint8),
+            )
+
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.StereoCamera",
+        DummyCam,
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.StereoCamera.camera_matrix",
+        np.eye(3),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.StereoCamera.dist_coeffs",
+        np.zeros(5),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.DepthEngine",
+        mock.Mock(
+            return_value=mock.Mock(
+                compute_depth=mock.Mock(
+                    return_value=np.zeros((1, 1), dtype=np.float32)
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.Yolo3DEngine",
+        mock.Mock(
+            return_value=mock.Mock(
+                segment=mock.Mock(
+                    return_value=([np.zeros((1, 1), dtype=np.uint8)], ["obj"])
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.PoseEstimator",
+        mock.Mock(return_value=mock.Mock(estimate=mock.Mock(return_value=[]))),
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.localize_objects",
+        mock.Mock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.CvBridge",
+        mock.Mock(
+            return_value=mock.Mock(
+                cv2_to_imgmsg=mock.Mock(return_value=Image())
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "lerobot_vision.visualization_node.ImageRectifier",
+        mock.Mock(
+            return_value=mock.Mock(
+                rectify=mock.Mock(side_effect=lambda l, r: (l, r))
+            )
+        ),
+    )
+
+    def create_pub(self, *args, **kwargs):
+        return mock.Mock()
+
+    monkeypatch.setattr(
+        rclpy.node.Node, "create_publisher", create_pub, raising=False
+    )
+
+    rclpy.init(args=None)
+    node = VisualizationNode("/tmp")
+    old_pub = node.pub
+    old_pub.publish = mock.Mock()
+    node._on_timer()
+    old_pub.publish.assert_called_once()
+
+    req = TogglePublisher.Request(publisher="overlay", enable=False)
+    node.toggle_srv.call(req)
+    node._on_timer()
+    old_pub.publish.assert_called_once()
+    assert node.pub is None
+
+    req = TogglePublisher.Request(publisher="overlay", enable=True)
+    node.toggle_srv.call(req)
+    node.pub.publish = mock.Mock()
+    node._on_timer()
+    node.pub.publish.assert_called_once()
     rclpy.shutdown()


### PR DESCRIPTION
## Summary
- allow toggling image publishers at runtime via a new `toggle_publisher` service
- document example service calls
- extend rclpy stub with `create_service`
- test enabling/disabling publishers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ed544f6b48331a1dd4c4e8aa5f2de