### PR TITLE
Add fusion publishing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ the computed depth map. These outputs can be enabled individually via the
 `publish_left_raw`, `publish_right_raw`, `publish_left_rectified`,
 `publish_right_rectified` and `publish_depth` ROS parameters.
 
+In addition, 3D detections are published on:
+
+* ``/robot/vision/points`` (`sensor_msgs/PointCloud2`)
+* ``/robot/vision/detections`` (`vision_msgs/Detection3DArray`)
+
 Start `web_video_server` to stream a topic in the browser:
 
 ```bash

--- a/ws/src/lerobot_vision/launch/system_launch.py
+++ b/ws/src/lerobot_vision/launch/system_launch.py
@@ -1,4 +1,11 @@
 # ws/src/lerobot_vision/launch/system_launch.py
+"""Launch demo nodes.
+
+The :class:`~lerobot_vision.visualization_node.VisualizationNode` publishes
+``/openyolo3d/overlay`` for image overlays as well as ``/robot/vision/points``
+and ``/robot/vision/detections`` for 3D data.
+"""
+
 from launch import LaunchDescription
 from launch_ros.actions import Node
 

--- a/ws/src/lerobot_vision/lerobot_vision/visualization_node.py
+++ b/ws/src/lerobot_vision/lerobot_vision/visualization_node.py
@@ -21,6 +21,7 @@ from .yolo3d_engine import Yolo3DEngine
 from .pose_estimator import PoseEstimator
 from .object_localizer import localize_objects
 from .image_rectifier import ImageRectifier
+from .fusion import FusionModule
 
 
 class VisualizationNode(Node):
@@ -54,11 +55,15 @@ class VisualizationNode(Node):
             .string_value
         )
         p_left_raw = (
-            self.get_parameter("publish_left_raw").get_parameter_value().integer_value
+            self.get_parameter("publish_left_raw")
+            .get_parameter_value()
+            .integer_value
             == 1
         )
         p_right_raw = (
-            self.get_parameter("publish_right_raw").get_parameter_value().integer_value
+            self.get_parameter("publish_right_raw")
+            .get_parameter_value()
+            .integer_value
             == 1
         )
         p_left_rect = (
@@ -74,11 +79,15 @@ class VisualizationNode(Node):
             == 1
         )
         p_depth = (
-            self.get_parameter("publish_depth").get_parameter_value().integer_value
+            self.get_parameter("publish_depth")
+            .get_parameter_value()
+            .integer_value
             == 1
         )
         p_overlay = (
-            self.get_parameter("publish_overlay").get_parameter_value().integer_value
+            self.get_parameter("publish_overlay")
+            .get_parameter_value()
+            .integer_value
             == 1
         )
         self.bridge = CvBridge()
@@ -86,6 +95,7 @@ class VisualizationNode(Node):
         self.depth_engine = DepthEngine()
         self.yolo_engine = Yolo3DEngine(ckpt_path)
         self.pose_estimator = PoseEstimator()
+        self.fusion = FusionModule(self)
         self.pub = (
             self.create_publisher(Image, "/openyolo3d/overlay", 10)
             if p_overlay
@@ -112,7 +122,9 @@ class VisualizationNode(Node):
             else None
         )
         self.pub_depth = (
-            self.create_publisher(Image, "/stereo/depth", 10) if p_depth else None
+            self.create_publisher(Image, "/stereo/depth", 10)
+            if p_depth
+            else None
         )
         self.rectifier: ImageRectifier | None = None
         self.create_timer(0.2, self._on_timer)
@@ -151,6 +163,7 @@ class VisualizationNode(Node):
             _ = localize_objects(
                 masks, depth, StereoCamera.camera_matrix, labels, poses
             )
+            self.fusion.publish(masks, labels, poses)
             overlay = self._draw_overlay(left_r, masks, labels, depth, poses)
             if self.pub:
                 msg = self.bridge.cv2_to_imgmsg(overlay, encoding="bgr8")


### PR DESCRIPTION
## Summary
- extend VisualizationNode to publish 3D data using FusionModule
- document new topics in launch file and README
- test that VisualizationNode publishes PointCloud2 and Detection3DArray

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed54b0a6083318b033fd0693e27d9