### PR TITLE
Add VisionGUI CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use `./run.sh` to activate the Conda environment (if present), source ROS 2 and 
 For a quick preview of the camera feed and a simple calibration helper you can run:
 
 ```bash
-python -m lerobot_vision.gui
+vision_gui
 ```
 
 The GUI contains checkboxes to enable rectified, depth and overlay views.

--- a/ws/src/lerobot_vision/lerobot_vision/gui.py
+++ b/ws/src/lerobot_vision/lerobot_vision/gui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import threading
 import tkinter as tk
 from pathlib import Path
@@ -386,3 +387,32 @@ class VisionGUI:  # pragma: no cover - GUI helper
         self.root.mainloop()
         self._running = False
         self.camera.release()
+
+
+def main(args: list[str] | None = None) -> None:
+    """Entry point for the ``vision_gui`` executable."""
+    parser = argparse.ArgumentParser(description="Simple camera GUI")
+    parser.add_argument(
+        "--config",
+        help="Path to calibration YAML file",
+        default=None,
+    )
+    parser.add_argument(
+        "--left",
+        type=int,
+        default=0,
+        help="Left camera device index",
+    )
+    parser.add_argument(
+        "--right",
+        type=int,
+        default=1,
+        help="Right camera device index",
+    )
+    opts = parser.parse_args(args)
+    cam = AsyncStereoCamera(opts.left, opts.right, config_path=opts.config)
+    VisionGUI(cam).run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/ws/src/lerobot_vision/setup.py
+++ b/ws/src/lerobot_vision/setup.py
@@ -27,6 +27,7 @@ setup(
             "nlp_node=lerobot_vision.nlp_node:main",
             "planner_node=lerobot_vision.planner_node:main",
             "control_node=lerobot_vision.control_node:main",
+            "vision_gui=lerobot_vision.gui:main",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- enable `vision_gui` CLI entry point
- add main() function in `gui.py` for standalone execution
- document the new command in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef60376a0833188eb48cc41d0e286