### PR TITLE
Enforce submodule population

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ provided checkboxes.
 
 ### 1. Install dependencies
 
-Run `./setup.sh` once to install system requirements, initialise submodules and build the workspace. This script assumes an Ubuntu system with ROS 2 Humble available via apt.
+Before running the setup script make sure the submodules are present:
 
+```bash
+git submodule update --init --recursive
+```
+
+Verify that every `external/*` directory contains files. `setup.sh` will exit if any of them are empty.
+
+Run `./setup.sh` once to install system requirements and build the workspace. This script assumes an Ubuntu system with ROS 2 Humble available via apt.
 ### 2. Create the Conda environment
 
 Create and activate the `lerobot-vision` Conda environment:

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
+# Fetch submodules before doing anything else
+git submodule update --init --recursive
+
+# Exit if any external directory is empty
+empty=0
+for d in external/*; do
+  if [ -d "$d" ] && [ -z "$(ls -A "$d")" ]; then
+    echo "Error: submodule directory '$d' is empty. Did git fetch succeed?" >&2
+    empty=1
+  fi
+done
+if [ $empty -ne 0 ]; then
+  echo "Submodule checkout failed. Please run 'git submodule update --init --recursive' manually." >&2
+  exit 1
+fi
+
 # Install system dependencies for ROS2 and Python tooling
 sudo apt update && sudo apt install -y git python3 python3-pip curl
 
@@ -12,16 +28,6 @@ fi
 # Initialize rosdep
 sudo rosdep init 2>/dev/null || true
 rosdep update
-
-# Fetch submodules
-git submodule update --init --recursive
-
-# Warn if any submodule directories are empty
-for d in external/*; do
-  if [ -d "$d" ] && [ -z "$(ls -A "$d")" ]; then
-    echo "Warning: submodule directory '$d' is empty. Did git fetch succeed?"
-  fi
-done
 
 # Install Python requirements
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- warn and exit in `setup.sh` if submodules fail to populate
- document the submodule requirement in the Getting started guide

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError for hydra, torch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685ef6106ab88331854f0cd1562480ee