### PR TITLE
Enhance setup and GUI usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Before running the setup script make sure the submodules are present:
 git submodule update --init --recursive
 ```
 
+After fetching the submodules run `./fetch_models.sh` to download the
+pretrained DOPE and YOLO3D checkpoints required by the demo.
+
 Verify that every `external/*` directory contains files. `setup.sh` will exit if any of them are empty.
 
 Run `./setup.sh` once to install system requirements and build the workspace. This script assumes an Ubuntu system with ROS 2 Humble available via apt.
@@ -51,7 +54,7 @@ Always activate the environment before running tests or `run.sh`.
 
 ### 3. Running the demo
 
-Use `./run.sh` to activate the Conda environment (if present), source ROS 2 and launch `system_launch.py` which starts the example nodes.
+Use `./run.sh` to activate the Conda environment (if present), source ROS 2 and launch `system_launch.py` which starts the example nodes. Pass `--gui` to start the GUI alongside the pipeline.
 
 For a quick preview of the camera feed and a simple calibration helper you can run:
 
@@ -60,7 +63,8 @@ vision_gui
 ```
 
 The GUI contains checkboxes to enable rectified, depth, disparity, mask and
-overlay views.
+overlay views. Additional buttons allow saving a screenshot or recording the
+current overlay for later analysis.
 
 ### 4. Project structure
 
@@ -115,6 +119,8 @@ The visualization node publishes the raw and rectified camera frames as well as
 the computed depth map. These outputs can be enabled individually via the
 `publish_left_raw`, `publish_right_raw`, `publish_left_rectified`,
 `publish_right_rectified` and `publish_depth` ROS parameters.
+The overlay view combines these results into an image showing bounding boxes,
+labels, distances, relative positions and pose axes for each detected object.
 
 In addition, 3D detections are published on:
 
@@ -128,6 +134,8 @@ ros2 service call /visualization_node/toggle_publisher \
   lerobot_vision/srv/TogglePublisher "{publisher: 'left_raw', enable: true}"
 ros2 service call /visualization_node/toggle_publisher \
   lerobot_vision/srv/TogglePublisher "{publisher: 'left_raw', enable: false}"
+ros2 service call /visualization_node/toggle_publisher \
+  lerobot_vision/srv/TogglePublisher "{publisher: 'overlay', enable: false}"
 ```
 
 Start `web_video_server` to stream a topic in the browser:

--- a/fetch_models.sh
+++ b/fetch_models.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Download DOPE and YOLO3D checkpoints into external/checkpoints
+mkdir -p external/checkpoints
+cd external/checkpoints
+
+fetch() {
+    url="$1"
+    out="$2"
+    if [ ! -f "$out" ]; then
+        echo "Downloading $out..."
+        curl -L -o "$out" "$url"
+    fi
+}
+
+fetch "https://github.com/NVlabs/Deep_Object_Pose/releases/download/v1.0/dope.tgz" dope.tgz
+fetch "https://github.com/ericwonghaha/OpenYOLO3D/releases/download/v1.0/yolo3d.tgz" yolo3d.tgz
+
+for archive in *.tgz; do
+    dir="${archive%.tgz}"
+    if [ ! -d "$dir" ]; then
+        tar -xzf "$archive"
+    fi
+done

--- a/run.sh
+++ b/run.sh
@@ -5,5 +5,8 @@ source /opt/ros/humble/setup.bash
 source "$HOME/miniconda3/etc/profile.d/conda.sh" 2>/dev/null || true
 conda activate lerobot-vision || true
 
-# Launch the system
+# Launch the system and optionally the GUI
+if [[ "$1" == "--gui" ]]; then
+    vision_gui &
+fi
 ros2 launch lerobot_vision system_launch.py

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,9 @@ set -e
 # Fetch submodules before doing anything else
 git submodule update --init --recursive
 
+# Fetch pretrained checkpoints for YOLO3D and DOPE
+./fetch_models.sh || true
+
 # Exit if any external directory is empty
 empty=0
 for d in external/*; do


### PR DESCRIPTION
## Summary
- add `fetch_models.sh` to download DOPE and YOLO3D checkpoints
- invoke the model fetch script in `setup.sh`
- launch GUI from `run.sh` with `--gui`
- extend `VisionGUI` with screenshot and recording features
- document new workflow and overlay outputs in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ef79e48608331a11d23da9f94ce7f