### PR TITLE
Fix submodule config and improve run script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,6 +11,3 @@
         path = external/isaac_ros_pose_estimation
         url = https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_pose_estimation.git
         branch = release-3.2
-[submodule "external/OpenYOLO3D/models/Mask3D/third_party/MinkowskiEngine"]
-       path = external/OpenYOLO3D/models/Mask3D/third_party/MinkowskiEngine
-       url = https://github.com/NVIDIA/MinkowskiEngine.git

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-source /opt/ros/humble/setup.bash
+if [ -f /opt/ros/humble/setup.bash ]; then
+    source /opt/ros/humble/setup.bash
+else
+    echo "ROS 2 Humble not found at /opt/ros/humble" >&2
+    echo "Please install ROS 2 Humble or update run.sh with the correct path." >&2
+    exit 1
+fi
 source "$HOME/miniconda3/etc/profile.d/conda.sh" 2>/dev/null || true
 conda activate lerobot-vision || true
 


### PR DESCRIPTION
## Summary
- remove invalid MinkowskiEngine submodule entry
- check for ROS2 installation in `run.sh`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hydra')*

------
https://chatgpt.com/codex/tasks/task_e_685fe328f35483319e8c9c6f9f4d7c92