### PR TITLE
Allow overriding ROS setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pretrained DOPE and YOLO3D checkpoints required by the demo.
 
 Verify that every `external/*` directory contains files. `setup.sh` will exit if any of them are empty.
 
-Run `./setup.sh` once to install system requirements and build the workspace. This script assumes an Ubuntu system with ROS 2 Humble available via apt.
+Run `./setup.sh` once to install system requirements and build the workspace. This script assumes an Ubuntu system with ROS 2 Humble available via apt. If your ROS 2 installation lives elsewhere, set the `ROS_SETUP` environment variable to the appropriate `setup.bash` before running the script.
 ### 2. Create the Conda environment
 
 Create and activate the `lerobot-vision` Conda environment:
@@ -58,6 +58,7 @@ Use `./run.sh` to activate the Conda environment (if present), source ROS 2 and
 ```bash
 ./run.sh --gui --left 2 --right 3 --config path/to/camera.yaml --side-by-side
 ```
+If ROS lives in a non‑standard location, set `ROS_SETUP` (or `ROS_DISTRO`) before running the script so it can locate the correct `setup.bash`.
 
 CUDA acceleration is enabled by default. Disable it with:
 

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -f /opt/ros/humble/setup.bash ]; then
-    source /opt/ros/humble/setup.bash
+ROS_DISTRO="${ROS_DISTRO:-humble}"
+ROS_SETUP="${ROS_SETUP:-/opt/ros/${ROS_DISTRO}/setup.bash}"
+
+if [ -f "$ROS_SETUP" ]; then
+    # Source the detected ROS 2 setup file
+    source "$ROS_SETUP"
 else
-    echo "ROS 2 Humble not found at /opt/ros/humble" >&2
-    echo "Please install ROS 2 Humble or update run.sh with the correct path." >&2
+    echo "ROS 2 distribution '$ROS_DISTRO' not found at $ROS_SETUP" >&2
+    echo "Please install ROS 2 or set ROS_SETUP to the correct path." >&2
     exit 1
 fi
 source "$HOME/miniconda3/etc/profile.d/conda.sh" 2>/dev/null || true

--- a/setup.sh
+++ b/setup.sh
@@ -44,5 +44,14 @@ then
 fi
 
 # Build the workspace
-source /opt/ros/humble/setup.bash
+ROS_DISTRO="${ROS_DISTRO:-humble}"
+ROS_SETUP="${ROS_SETUP:-/opt/ros/${ROS_DISTRO}/setup.bash}"
+
+if [ -f "$ROS_SETUP" ]; then
+  source "$ROS_SETUP"
+else
+  echo "ROS 2 distribution '$ROS_DISTRO' not found at $ROS_SETUP" >&2
+  echo "Please install ROS 2 or set ROS_SETUP to the correct path." >&2
+  exit 1
+fi
 colcon build --symlink-install --workspace ws


### PR DESCRIPTION
## Summary
- make `run.sh` detect ROS setup path using `ROS_DISTRO` or `ROS_SETUP`
- allow the same override when building in `setup.sh`
- mention the override in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffbfd04d88331a9f930c018089cef