### PR TITLE
Integrate SuperPointSLAM3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ lightweight wrapper around NVIDIA DOPE for pose estimation. Heavy weight
 dependencies (YOLO3D, StereoAnywhere, MoveIt etc.) are provided as Git
 submodules under `external/`.
 
+
 Before building the workspace you must fetch these submodules:
 `git submodule update --init --recursive`.
 
@@ -64,6 +65,12 @@ CUDA acceleration is enabled by default. Disable it with:
 
 ```bash
 ros2 launch lerobot_vision system_launch.py use_cuda:=false
+```
+
+Launch the complete setup including SLAM with:
+
+```bash
+ros2 launch lerobot_vision slam_system.launch.py
 ```
 
 Set the `OPENAI_API_KEY` environment variable to enable the NLP node.

--- a/tests/test_slam_node.py
+++ b/tests/test_slam_node.py
@@ -1,0 +1,29 @@
+import numpy as np
+from unittest import mock
+import rclpy
+
+from lerobot_vision.slam_node import SlamNode
+
+
+class DummyCam:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_frames(self):
+        return np.zeros((1, 1, 3), dtype=np.uint8), np.zeros((1, 1, 3), dtype=np.uint8)
+
+
+def test_slam_node(monkeypatch, tmp_path):
+    slam_inst = mock.Mock(track=mock.Mock(return_value=[0, 0, 0]), get_map=mock.Mock(return_value=b"map"))
+    monkeypatch.setattr("lerobot_vision.slam_node.SLAMSystem", mock.Mock(return_value=slam_inst))
+    monkeypatch.setattr("lerobot_vision.slam_node.StereoCamera", DummyCam)
+    rclpy.init(args=None)
+    node = SlamNode()
+    node.pub_map.publish = mock.Mock()
+    node.pub_pose.publish = mock.Mock()
+    node.map_output = str(tmp_path / "map.npz")
+    node._on_timer()
+    node.pub_map.publish.assert_called_once()
+    node.pub_pose.publish.assert_called_once()
+    assert (tmp_path / "map.npz").exists()
+    rclpy.shutdown()

--- a/ws/src/lerobot_vision/launch/slam_system.launch.py
+++ b/ws/src/lerobot_vision/launch/slam_system.launch.py
@@ -1,0 +1,85 @@
+"""Launch demo nodes including SLAM."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    left_arg = DeclareLaunchArgument(
+        "left", default_value="0", description="Left camera index"
+    )
+    right_arg = DeclareLaunchArgument(
+        "right", default_value="1", description="Right camera index"
+    )
+    sbs_arg = DeclareLaunchArgument(
+        "side_by_side",
+        default_value="false",
+        description="Single device providing side-by-side frames",
+    )
+    config_arg = DeclareLaunchArgument(
+        "camera_config",
+        default_value="$(find-pkg-share lerobot_vision)/config/camera.yaml",
+        description="Path to calibration file",
+    )
+    map_arg = DeclareLaunchArgument(
+        "map_output", default_value="", description="Optional map output"
+    )
+    return LaunchDescription(
+        [
+            left_arg,
+            right_arg,
+            sbs_arg,
+            config_arg,
+            map_arg,
+            Node(
+                package="stereoanywhere",
+                executable="stereo_anywhere_node",
+                name="stereo_anywhere",
+            ),
+            Node(
+                package="isaac_ros_pose_estimation",
+                executable="dope_pose_estimation",
+                name="isaac_dope",
+            ),
+            Node(
+                package="lerobot_vision",
+                executable="visualization_node",
+                name="yolo3d_viz",
+                parameters=[
+                    {"camera_config": LaunchConfiguration("camera_config")},
+                    {"left_idx": LaunchConfiguration("left")},
+                    {"right_idx": LaunchConfiguration("right")},
+                    {"side_by_side": LaunchConfiguration("side_by_side")},
+                ],
+            ),
+            Node(
+                package="lerobot_vision",
+                executable="nlp_node",
+                name="nlp",
+            ),
+            Node(
+                package="lerobot_vision",
+                executable="planner_node",
+                name="planner",
+            ),
+            Node(
+                package="lerobot_vision",
+                executable="control_node",
+                name="controller",
+            ),
+            Node(
+                package="lerobot_vision",
+                executable="slam_node",
+                name="slam",
+                parameters=[
+                    {"camera_config": LaunchConfiguration("camera_config")},
+                    {"left_idx": LaunchConfiguration("left")},
+                    {"right_idx": LaunchConfiguration("right")},
+                    {"side_by_side": LaunchConfiguration("side_by_side")},
+                    {"map_output": LaunchConfiguration("map_output")},
+                ],
+            ),
+        ]
+    )

--- a/ws/src/lerobot_vision/lerobot_vision/__init__.py
+++ b/ws/src/lerobot_vision/lerobot_vision/__init__.py
@@ -9,6 +9,7 @@ from .object_localizer import localize_objects
 from .fusion import FusionModule
 from .stereo_calibrator import StereoCalibrator
 from .calibrate_cli import main as calibrate_cli
+from .slam_node import SlamNode
 
 __all__ = [
     "StereoCamera",
@@ -20,4 +21,5 @@ __all__ = [
     "FusionModule",
     "StereoCalibrator",
     "calibrate_cli",
+    "SlamNode",
 ]

--- a/ws/src/lerobot_vision/lerobot_vision/slam_node.py
+++ b/ws/src/lerobot_vision/lerobot_vision/slam_node.py
@@ -1,0 +1,89 @@
+# ws/src/lerobot_vision/lerobot_vision/slam_node.py
+"""SLAM node using SuperPointSLAM3."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import PointCloud2
+from std_msgs.msg import String
+
+from .camera_interface import StereoCamera
+
+try:
+    from SuperPointSLAM3 import System as SLAMSystem  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency
+    SLAMSystem = None
+    logging.error("SuperPointSLAM3 import failed: %s", exc)
+
+
+class SlamNode(Node):
+    """Node running SuperPointSLAM3."""
+
+    def __init__(self) -> None:
+        super().__init__("slam_node")
+        base = Path(__file__).resolve().parent.parent
+        default_cfg = base / "config" / "camera.yaml"
+        self.declare_parameter("camera_config", str(default_cfg))
+        self.declare_parameter("left_idx", 0)
+        self.declare_parameter("right_idx", 1)
+        self.declare_parameter("side_by_side", False)
+        self.declare_parameter("map_output", "")
+        cfg = (
+            self.get_parameter("camera_config").get_parameter_value().string_value
+        )
+        idx_left = (
+            self.get_parameter("left_idx").get_parameter_value().integer_value
+        )
+        idx_right = (
+            self.get_parameter("right_idx").get_parameter_value().integer_value
+        )
+        side_by_side = (
+            self.get_parameter("side_by_side")
+            .get_parameter_value()
+            .integer_value
+            == 1
+        )
+        self.map_output = (
+            self.get_parameter("map_output").get_parameter_value().string_value
+        )
+        if SLAMSystem is None:
+            raise RuntimeError("SuperPointSLAM3 unavailable")
+        self.slam = SLAMSystem()
+        self.camera = StereoCamera(
+            idx_left, idx_right, config_path=cfg, side_by_side=side_by_side
+        )
+        self.pub_map = self.create_publisher(PointCloud2, "/slam/map", 10)
+        self.pub_pose = self.create_publisher(String, "/slam/pose", 10)
+        self.create_timer(0.1, self._on_timer)
+
+    def _on_timer(self) -> None:
+        left, right = self.camera.get_frames()
+        pose = self.slam.track(left, right)  # type: ignore[attr-defined]
+        map_data = self.slam.get_map()  # type: ignore[attr-defined]
+        self.pub_pose.publish(String(data=str(pose)))
+        self.pub_map.publish(PointCloud2(data=map_data))
+        if self.map_output:
+            try:
+                np.savez(self.map_output, map=map_data)
+            except Exception as exc:  # pragma: no cover - filesystem
+                logging.error("Failed to save map: %s", exc)
+
+
+def main(args: list[str] | None = None) -> None:
+    """Entry point for the ``slam_node`` executable."""
+    rclpy.init(args=args)
+    node = SlamNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/ws/src/lerobot_vision/setup.py
+++ b/ws/src/lerobot_vision/setup.py
@@ -13,7 +13,14 @@ setup(
             [f"resources/{package_name}"],
         ),
         (f"share/{package_name}", ["package.xml"]),
-        (f"share/{package_name}/launch", ["launch/system_launch.py", "launch/view_detections.launch.py"]),
+        (
+            f"share/{package_name}/launch",
+            [
+                "launch/system_launch.py",
+                "launch/slam_system.launch.py",
+                "launch/view_detections.launch.py",
+            ],
+        ),
         (f"share/{package_name}/config", ["config/camera.yaml"]),
         (f"share/{package_name}/rviz", ["rviz/view_detections.rviz"]),
     ],
@@ -31,6 +38,7 @@ setup(
             "planner_node=lerobot_vision.planner_node:main",
             "control_node=lerobot_vision.control_node:main",
             "vision_gui=lerobot_vision.gui:main",
+            "slam_node=lerobot_vision.slam_node:main",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- add SuperPointSLAM3 as submodule under `external/`
- implement `SlamNode` and export it
- launch SLAM via `slam_system.launch.py`
- install SLAM node entry point in setup
- clarify README about existing SuperPointSLAM3 submodule
- unit tests for the SLAM node
- remove extra SuperPointSLAM3 submodule entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68626a36646c8331811c3771985c2bcf