### PR TITLE
Add minimal FastAPI web interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ flake8
 black
 PyYAML
 matplotlib
+fastapi
+uvicorn

--- a/tests/test_web_interface.py
+++ b/tests/test_web_interface.py
@@ -1,0 +1,43 @@
+import numpy as np
+from fastapi.testclient import TestClient
+
+from lerobot_vision import web_interface as web
+
+
+def test_list_cameras(monkeypatch):
+    class DummyCap:
+        def __init__(self, idx: int) -> None:
+            self.idx = idx
+
+        def isOpened(self) -> bool:
+            return self.idx < 2
+
+        def release(self) -> None:
+            pass
+
+    monkeypatch.setattr(web.cv2, "VideoCapture", lambda idx: DummyCap(idx))
+    client = TestClient(web.app)
+    resp = client.get("/cameras")
+    assert resp.status_code == 200
+    assert resp.json() == {"cameras": [0, 1]}
+
+
+def test_stream_generator(monkeypatch):
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    class DummyCam:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_frames(self):
+            return frame, frame
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(web, "AsyncStereoCamera", DummyCam)
+    web.manager.start()
+    gen = web._mjpeg_generator("left")
+    chunk = next(gen)
+    assert b"--frame" in chunk
+    web.manager.stop()

--- a/ws/src/lerobot_vision/lerobot_vision/web_interface.py
+++ b/ws/src/lerobot_vision/lerobot_vision/web_interface.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Minimal FastAPI web interface for the stereo system."""
+
+import cv2
+from fastapi import FastAPI, Response
+from fastapi.responses import StreamingResponse, JSONResponse
+
+from .camera_interface import AsyncStereoCamera
+
+app = FastAPI(title="LeRobot Web")
+
+
+class CameraManager:
+    """Simple manager wrapping :class:`AsyncStereoCamera`."""
+
+    def __init__(self) -> None:
+        self.camera: AsyncStereoCamera | None = None
+
+    def start(
+        self, left: int = 0, right: int = 1, side_by_side: bool = False
+    ) -> None:
+        if self.camera:
+            self.camera.release()
+        self.camera = AsyncStereoCamera(left, right, side_by_side=side_by_side)
+
+    def frames(self) -> tuple[bytes, bytes]:
+        if not self.camera:
+            raise RuntimeError("camera not started")
+        left, right = self.camera.get_frames()
+        _, lbuf = cv2.imencode(".jpg", left)
+        _, rbuf = cv2.imencode(".jpg", right)
+        return lbuf.tobytes(), rbuf.tobytes()
+
+    def stop(self) -> None:
+        if self.camera:
+            self.camera.release()
+            self.camera = None
+
+
+manager = CameraManager()
+
+
+@app.get("/")
+def index() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/cameras")
+def list_cameras(max_index: int = 4) -> JSONResponse:
+    indices: list[int] = []
+    for idx in range(max_index):
+        cap = cv2.VideoCapture(idx)
+        if cap.isOpened():
+            indices.append(idx)
+        cap.release()
+    return JSONResponse(content={"cameras": indices})
+
+
+def _mjpeg_generator(side: str = "left"):
+    while True:
+        lbuf, rbuf = manager.frames()
+        buf = lbuf if side == "left" else rbuf
+        yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + buf + b"\r\n"
+
+
+@app.get("/stream/{side}")
+def stream(side: str) -> StreamingResponse:
+    if side not in {"left", "right"}:
+        return Response(status_code=404)
+    return StreamingResponse(
+        _mjpeg_generator(side),
+        media_type="multipart/x-mixed-replace; boundary=frame",
+    )
+
+
+@app.post("/start")
+def start(
+    left: int = 0, right: int = 1, side_by_side: bool = False
+) -> dict[str, str]:
+    manager.start(left, right, side_by_side)
+    return {"status": "started"}
+
+
+@app.post("/stop")
+def stop() -> dict[str, str]:
+    manager.stop()
+    return {"status": "stopped"}


### PR DESCRIPTION
## Summary
- add a new `web_interface` module with a simple FastAPI server
- expose endpoints to enumerate cameras, start/stop capture and stream MJPEG
- include test coverage for the new API
- update requirements with FastAPI and Uvicorn

## Testing
- `flake8 ws/src/lerobot_vision/lerobot_vision/web_interface.py tests/test_web_interface.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686538ebae348331a651e947298ea02f