### PR TITLE
Expand web interface

### DIFF
--- a/tests/test_camera_interface.py
+++ b/tests/test_camera_interface.py
@@ -54,3 +54,29 @@ def test_side_by_side(monkeypatch):
     assert left.shape[1] == right.shape[1] == 10
     assert np.all(left == 1)
     assert np.all(right == 2)
+
+
+def test_camera_properties(monkeypatch):
+    class DummyCap:
+        def __init__(self):
+            self.props = {}
+
+        def read(self):
+            return True, np.zeros((1, 1, 3), dtype=np.uint8)
+
+        def release(self):
+            pass
+
+        def set(self, prop, value):
+            self.props[prop] = value
+
+        def get(self, prop):
+            return self.props.get(prop, 0)
+
+    monkeypatch.setattr("cv2.VideoCapture", lambda idx: DummyCap())
+    cam = StereoCamera()
+    cam.set_properties(width=320, height=240, fps=25)
+    info = cam.get_properties()
+    assert info["width"] == 320
+    assert info["height"] == 240
+    assert info["fps"] == 25

--- a/tests/test_web_interface.py
+++ b/tests/test_web_interface.py
@@ -41,3 +41,37 @@ def test_stream_generator(monkeypatch):
     chunk = next(gen)
     assert b"--frame" in chunk
     web.manager.stop()
+
+
+def test_camera_info(monkeypatch):
+    class DummyCap:
+        def __init__(self, *_):
+            pass
+
+        def isOpened(self) -> bool:
+            return True
+
+        def get(self, prop):
+            mapping = {
+                web.cv2.CAP_PROP_FRAME_WIDTH: 640,
+                web.cv2.CAP_PROP_FRAME_HEIGHT: 480,
+                web.cv2.CAP_PROP_FPS: 30,
+            }
+            return mapping[prop]
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(web.cv2, "VideoCapture", lambda i: DummyCap())
+    client = TestClient(web.app)
+    resp = client.get("/camera_info?index=0")
+    assert resp.status_code == 200
+    assert resp.json() == {"width": 640, "height": 480, "fps": 30}
+
+
+def test_robot_move():
+    client = TestClient(web.app)
+    resp = client.post("/robot/move", params={"positions": "1,2"})
+    assert resp.json() == {"status": "ok"}
+    resp = client.get("/robot/positions")
+    assert resp.json() == {"positions": [1.0, 2.0]}

--- a/ws/src/lerobot_vision/lerobot_vision/camera_interface.py
+++ b/ws/src/lerobot_vision/lerobot_vision/camera_interface.py
@@ -39,6 +39,33 @@ class StereoCamera:
         self.left_cap = cv2.VideoCapture(left_idx)
         self.right_cap = None if side_by_side else cv2.VideoCapture(right_idx)
 
+    def set_properties(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        fps: int | None = None,
+    ) -> None:
+        """Set basic capture properties on both cameras."""
+        if width is not None:
+            self.left_cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+            if self.right_cap is not None:
+                self.right_cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+        if height is not None:
+            self.left_cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+            if self.right_cap is not None:
+                self.right_cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+        if fps is not None:
+            self.left_cap.set(cv2.CAP_PROP_FPS, fps)
+            if self.right_cap is not None:
+                self.right_cap.set(cv2.CAP_PROP_FPS, fps)
+
+    def get_properties(self) -> dict[str, int]:
+        """Return capture properties of the left camera."""
+        width = int(self.left_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(self.left_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = int(self.left_cap.get(cv2.CAP_PROP_FPS))
+        return {"width": width, "height": height, "fps": fps}
+
     def get_frames(self) -> Tuple[np.ndarray, np.ndarray]:
         """Retrieve frames from both cameras.
 


### PR DESCRIPTION
## Summary
- add property setters and getters to `StereoCamera`
- expose camera info and settings in the FastAPI app
- add a very small `RobotManager` with move & position endpoints
- cover the new functions with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865574223f083319307d9bea28cab74