### PR TITLE
Add calibration web sockets and YAML saving

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -52,6 +52,19 @@
     <img src="/stream/left" width="320">
     <img src="/stream/right" width="320">
 </div>
+<h2>Calibration</h2>
+<form action="/calibration/start" method="post">
+    Board width: <input type="number" name="board_w" value="7">
+    Board height: <input type="number" name="board_h" value="6">
+    Square size: <input type="number" step="0.1" name="size" value="1.0">
+    <button type="submit">Start Calibration</button>
+</form>
+<form action="/calibration/capture" method="post">
+    <button type="submit">Capture</button>
+</form>
+<form action="/calibration/finish" method="post">
+    <button type="submit">Finish</button>
+</form>
 <div>
     <h3>Model</h3>
     <select id="model_select" onchange="selectModel()"></select>

--- a/ws/src/lerobot_vision/lerobot_vision/camera_interface.py
+++ b/ws/src/lerobot_vision/lerobot_vision/camera_interface.py
@@ -121,8 +121,20 @@ class StereoCamera:
 class AsyncStereoCamera(StereoCamera):  # pragma: no cover - optional helper
     """Stereo camera that captures frames on a background thread."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        left_idx: int = 0,
+        right_idx: int = 1,
+        config_path: str | None = None,
+        side_by_side: bool = False,
+    ) -> None:
+        if config_path is None:
+            default = Path("calibration.yaml")
+            if default.exists():
+                config_path = str(default)
+        super().__init__(
+            left_idx, right_idx, config_path=config_path, side_by_side=side_by_side
+        )
         self._frame_left: np.ndarray | None = None
         self._frame_right: np.ndarray | None = None
         self._running = True


### PR DESCRIPTION
## Summary
- stream frames over `/ws/calibration/<side>`
- expose chessboard options on the sample HTML page
- save calibration results to `calibration.yaml`
- load calibration YAML automatically
- test calibration flow including YAML persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656f7900988331aed2d48dbafe758e